### PR TITLE
Updated from depreciated wiringpi2 to wiringpi library

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project consists of code and models for an 8mm film scanner project based around a Raspberry Pi model B and camera module.
 Most of the code is written in Python.
 
+This project is licensed under the 3-Clause BSD License.
+
 The project is designed to be able to reliably capture each frame of a reel of 8mm film 
 (Super 8 or Standard 8) as a high quality photo. Bracketing is possible to cope with underexposed
 or dense film.

--- a/rpiTelecine/control.py
+++ b/rpiTelecine/control.py
@@ -11,7 +11,7 @@
 # 	can be used as GPIOs
 # 	
 # Version 1 of the PCB is 10x10cm with pin headers for the motors,
-# 2 x power LEDs, Raspberry Pi model B and GPIO. Wiringpi2 is used
+# 2 x power LEDs, Raspberry Pi model B and GPIO. Wiringpi is used
 # for control. The PCB takes a 3A+ 12V power supply, and provides
 # power for the Pi using the 5V pin of the Pi's GPIO header.
 # For the two power LEDs, XPPower LDU0516S350 (or similar with
@@ -24,7 +24,7 @@
 # The LED power and DC motors are switched using Mosfets.
 #
 # Prerequisites: 
-#   Wiringpi2 for Python
+#   Wiringpi for Python
 #   SPI needs to be enabled from raspi-config so the correct kernel 
 #   modules are loaded on boot.
 #

--- a/rpiTelecine/control.py
+++ b/rpiTelecine/control.py
@@ -57,7 +57,7 @@
 
 
 from __future__ import division
-from wiringpi2 import *
+from wiringpi import *
 
 class tcControl():
     


### PR DESCRIPTION
wiringpi2 has been depreciated, so this moves to wiringpi. 

I discovered this when trying to run on a raspi 3 model b and kept getting errors about wrong hardware. wiringpi was updated to resolve this but wiringpi2 never was. 

Also, included license comment in the README.